### PR TITLE
Correct spacing in company name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,7 +48,7 @@ The following are members of the TSC for the duration of the trial:
  - Olivier Poupeney, @opoupeney, Symphony
  - Cara Delia, @cdeliaRH, Red Hat
  - Riko Eksteen, @rikoe, Adaptive
- - Jon Freedman, @jonfreedman, Point 72
+ - Jon Freedman, @jonfreedman, Point72
  - Elspeth Minty, @eminty69, RBC
 
 ## Ways of Working


### PR DESCRIPTION
Just a little typo, the company name has no space. 